### PR TITLE
Fix typo in scanner log message

### DIFF
--- a/boxmanager/templates/scanners.html
+++ b/boxmanager/templates/scanners.html
@@ -100,7 +100,7 @@
                 document.getElementById('result').textContent = err
               }
             })
-            console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
+            console.log(`Started continuous decode from camera with id ${selectedDeviceId}`)
           })
 
           document.getElementById('resetButton').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- correct a misspelled console message in scanners.html

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68405d537ac4832da7dd81e84d086411