### PR TITLE
Fix redirect for duplicate username case

### DIFF
--- a/boxmanager/blueprints/routes_main.py
+++ b/boxmanager/blueprints/routes_main.py
@@ -49,7 +49,7 @@ def register():
 
         if User.query.filter_by(username=username).first():
             flash('Username already exists')
-            return redirect(url_for('register'))
+            return redirect(url_for('main.register'))
 
         new_user = User(username=username, password=hashed_password)
         db.session.add(new_user)


### PR DESCRIPTION
## Summary
- ensure the register route redirects to the correct endpoint when username already exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405de3f320832d97f26d1492b80236