### PR TITLE
Add item barcode API

### DIFF
--- a/boxmanager/templates/box_details.html
+++ b/boxmanager/templates/box_details.html
@@ -6,7 +6,10 @@
 <h2>Items</h2>
 <ul class="list-group">
     {% for item in box.items %}
-    <li class="list-group-item">{{ item.name }} - {{ item.description }} - Qty: {{ item.quantity }}</li>
+    <li class="list-group-item">
+        {{ item.name }} - {{ item.description }} - Qty: {{ item.quantity }}
+        {% if item.ean_code %}<br><small>EAN: {{ item.ean_code }}</small>{% endif %}
+    </li>
     {% endfor %}
 </ul>
 <a class="btn btn-primary mt-3" href="{{ url_for('boxes.add_item', box_id=box.id) }}">Add Item to Box</a>

--- a/boxmanager/templates/scanners.html
+++ b/boxmanager/templates/scanners.html
@@ -15,6 +15,7 @@
 </div>
 <label>Result:</label>
 <pre><code id="result"></code></pre>
+<div id="itemDetails" class="mt-3"></div>
 <script src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
 <script>
 window.addEventListener('load', function () {
@@ -37,6 +38,16 @@ window.addEventListener('load', function () {
       codeReader.decodeFromVideoDevice(selectedDeviceId, 'video', (result, err) => {
         if (result) {
           document.getElementById('result').textContent = result.text;
+          fetch(`/api/items/${result.text}`)
+            .then(r => r.ok ? r.json() : null)
+            .then(data => {
+              const detailDiv = document.getElementById('itemDetails');
+              if (data) {
+                detailDiv.textContent = `Item: ${data.name} (qty ${data.quantity})`;
+              } else {
+                detailDiv.textContent = 'Item not found';
+              }
+            });
         }
         if (err && !(err instanceof ZXing.NotFoundException)) {
           document.getElementById('result').textContent = err;
@@ -46,6 +57,7 @@ window.addEventListener('load', function () {
     document.getElementById('resetButton').addEventListener('click', () => {
       codeReader.reset();
       document.getElementById('result').textContent = '';
+      document.getElementById('itemDetails').textContent = '';
     });
   }).catch((err) => { console.error(err); });
 });


### PR DESCRIPTION
## Summary
- allow adding items with EAN code
- expose `/api/items/<ean_code>` to look up item details by code
- show item EAN codes in box details page
- improve scanner page to fetch item info by code
- cover new behaviour in unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68408743ddfc832d9742d71df78837fe