### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+BoxManager.zip
+tests/

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyd
 BoxManager.zip
 tests/
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 5000
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ docker build -t boxmanager .
 docker run -p 5000:5000 boxmanager
 ```
 
+### Running with Docker Compose
+
+To launch the application together with a PostgreSQL database run:
+```bash
+docker-compose up --build
+```
+
+The compose configuration provides the database service and sets
+`SECRET_KEY` and `DATABASE_URL` environment variables for the app.
+
 ## Running tests
 
 The tests use a temporary SQLite database. Ensure `pytest` is installed and run:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Run the development server:
 python run.py
 ```
 
+### Running with Docker
+
+Build the image and start the container:
+```bash
+docker build -t boxmanager .
+docker run -p 5000:5000 boxmanager
+```
+
 ## Running tests
 
 The tests use a temporary SQLite database. Ensure `pytest` is installed and run:

--- a/boxmanager/config.py
+++ b/boxmanager/config.py
@@ -1,9 +1,13 @@
 from datetime import timedelta
+import os
 
 
 class Config:
-    SECRET_KEY = 'super_secretoso'
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'super_secretoso')
     SESSION_TYPE = 'filesystem'
-    SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:atx11525@192.168.1.103:5432/box_manager'
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        'DATABASE_URL',
+        'postgresql://postgres:atx11525@192.168.1.103:5432/box_manager',
+    )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     PERMANENT_SESSION_LIFETIME = timedelta(minutes=15)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: box_manager
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    depends_on:
+      - db
+    environment:
+      SECRET_KEY: super_secretoso
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/box_manager
+volumes:
+  db-data:

--- a/run.py
+++ b/run.py
@@ -3,4 +3,6 @@ from boxmanager import create_app
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Listen on all interfaces so the app is reachable from outside the
+    # container when running under Docker.
+    app.run(host="0.0.0.0", debug=True)


### PR DESCRIPTION
## Summary
- allow configuration via environment variables
- add Dockerfile and ignore files for container build
- document running the app in Docker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408ac30bb4832d886f1d88f09b9559